### PR TITLE
feat: add schema type object to  generation

### DIFF
--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -903,6 +903,7 @@ func (g *Generator) newSchemaFromType(t reflect.Type) *SchemaOrRef {
 			Schema: &Schema{
 				Nullable:    true,
 				Description: "Value of any type, including null",
+				Type:        "object",
 			},
 		}
 	}
@@ -1255,7 +1256,7 @@ func fieldNameFromTag(sf reflect.StructField, tagName string) string {
 	return name
 }
 
-/// parseExampleValue is used to transform the string representation of the example value to the correct type.
+// / parseExampleValue is used to transform the string representation of the example value to the correct type.
 func parseExampleValue(t reflect.Type, value string) (interface{}, error) {
 	// If the type implements Exampler use the ParseExample method to create the example
 	i, ok := reflect.New(t).Interface().(Exampler)

--- a/openapi/generator_test.go
+++ b/openapi/generator_test.go
@@ -154,7 +154,7 @@ func TestSchemaFromInterface(t *testing.T) {
 
 	schema := g.newSchemaFromType(tofEmptyInterface)
 	assert.NotNil(t, schema)
-	assert.Empty(t, schema.Type)
+	assert.Equal(t, "object", schema.Type)
 	assert.Empty(t, schema.Format)
 	assert.True(t, schema.Nullable)
 	assert.NotEmpty(t, schema.Description)

--- a/testdata/spec.json
+++ b/testdata/spec.json
@@ -237,7 +237,8 @@
                     },
                     "value": {
                         "description": "A nullable value of arbitrary type",
-                        "nullable": true
+                        "nullable": true,
+                        "type": "object"
                     }
                 }
             }

--- a/testdata/spec.yaml
+++ b/testdata/spec.yaml
@@ -151,6 +151,7 @@ components:
         value:
           description: "A nullable value of arbitrary type"
           nullable: true
+          type: object
   securitySchemes:
     api_key:
       type: apiKey


### PR DESCRIPTION
add change on generator to solve the following redocly like issues:

The `type` field must be defined when the `nullable` field is used.

spec.yaml#/components/schemas/ApirouterListExpressionItem/properties/expression/nullable

3031 | expression:
3032 |     description: Value of any type, including null
3033 |     nullable: true
3034 | id:
3035 |     type: string
Error was generated by the spec rule.
Jira: CXP-2968