### PR TITLE
feat: add options to open api generation to include operations with labels

### DIFF
--- a/fizz.go
+++ b/fizz.go
@@ -267,9 +267,9 @@ func (g *RouterGroup) Handle(path, method string, infos []OperationOption, handl
 	return g
 }
 
-// OpenAPI returns a Gin HandlerFunc that serves
-// the marshalled OpenAPI specification of the API.
-func (f *Fizz) OpenAPI(info *openapi.Info, ct string) gin.HandlerFunc {
+// OpenAPI returns a Gin HandlerFunc that serves a copy of
+// the marshalled OpenAPI specification of the API with given options.
+func (f *Fizz) OpenAPI(info *openapi.Info, ct string, opts ...openapi.Option) gin.HandlerFunc {
 	f.gen.SetInfo(info)
 
 	ct = strings.ToLower(ct)
@@ -279,11 +279,11 @@ func (f *Fizz) OpenAPI(info *openapi.Info, ct string) gin.HandlerFunc {
 	switch ct {
 	case "json":
 		return func(c *gin.Context) {
-			c.JSON(200, f.gen.API())
+			c.JSON(200, f.gen.GenerateOpenAPI(opts...))
 		}
 	case "yaml":
 		return func(c *gin.Context) {
-			c.YAML(200, f.gen.API())
+			c.YAML(200, f.gen.GenerateOpenAPI(opts...))
 		}
 	}
 	panic("invalid content type, use JSON or YAML")
@@ -422,6 +422,14 @@ func WithoutSecurity() func(*openapi.OperationInfo) {
 func XInternal() func(*openapi.OperationInfo) {
 	return func(o *openapi.OperationInfo) {
 		o.XInternal = true
+	}
+}
+
+// Labels adds labels to the operation to be used for grouping.
+// This is not part of the OpenAPI spec.
+func Labels(labels []string) func(*openapi.OperationInfo) {
+	return func(o *openapi.OperationInfo) {
+		o.Labels = labels
 	}
 }
 

--- a/openapi/generator_test.go
+++ b/openapi/generator_test.go
@@ -1032,3 +1032,12 @@ func gen(t *testing.T) *Generator {
 
 	return g
 }
+
+func TestIncludeLabels(t *testing.T) {
+	g := gen(t)
+
+	labels := []string{"first", "second"}
+	result := g.GenerateOpenAPI(WithLabeledOperations(labels))
+
+	assert.Equal(t, labels, result.IncludeLabels)
+}

--- a/openapi/operation.go
+++ b/openapi/operation.go
@@ -15,6 +15,10 @@ type OperationInfo struct {
 	Security          []*SecurityRequirement
 	XCodeSamples      []*XCodeSample
 	XInternal         bool
+
+	// Labels is a list of labels that can be used to group operations.
+	// This is not part of the OpenAPI spec.
+	Labels []string
 }
 
 // ResponseHeader represents a single header that

--- a/openapi/spec.go
+++ b/openapi/spec.go
@@ -1,6 +1,8 @@
 package openapi
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 // OpenAPI represents the root document object of
 // an OpenAPI document.
@@ -13,6 +15,29 @@ type OpenAPI struct {
 	Tags       []*Tag                 `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Security   []*SecurityRequirement `json:"security,omitempty" yaml:"security,omitempty"`
 	XTagGroups []*XTagGroup           `json:"x-tagGroups,omitempty" yaml:"x-tagGroups,omitempty"`
+
+	// Internal options. These are not part of the OpenAPI spec.
+	// IncludeLabels is a list of labels to include those endpoints in the generated OpenAPI spec.
+	// By default, labeled endpoints are not included.
+	IncludeLabels []string `json:"-" yaml:"-"`
+}
+
+func Clone(o *OpenAPI) (OpenAPI, error) {
+	var newCopy OpenAPI
+
+	data, err := json.Marshal(o)
+	if err != nil {
+		return OpenAPI{}, err
+	}
+
+	err = json.Unmarshal(data, &newCopy)
+	if err != nil {
+		return OpenAPI{}, err
+	}
+
+	newCopy.IncludeLabels = o.IncludeLabels
+
+	return newCopy, nil
 }
 
 // Components holds a set of reusable objects for different
@@ -87,6 +112,10 @@ type PathItem struct {
 	TRACE       *Operation        `json:"trace,omitempty" yaml:"trace,omitempty"`
 	Servers     []*Server         `json:"servers,omitempty" yaml:"servers,omitempty"`
 	Parameters  []*ParameterOrRef `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+}
+
+func GetOperations(p *PathItem) []*Operation {
+	return []*Operation{p.GET, p.PUT, p.POST, p.DELETE, p.OPTIONS, p.HEAD, p.PATCH, p.TRACE}
 }
 
 // Reference is a simple object to allow referencing
@@ -200,6 +229,10 @@ type Operation struct {
 	Security     []*SecurityRequirement `json:"security" yaml:"security"`
 	XCodeSamples []*XCodeSample         `json:"x-codeSamples,omitempty" yaml:"x-codeSamples,omitempty"`
 	XInternal    bool                   `json:"x-internal,omitempty" yaml:"x-internal,omitempty"`
+
+	// Labels is a list of labels that can be used to group operations.
+	// This is not part of the OpenAPI spec.
+	Labels []string `json:"-" yaml:"-"`
 }
 
 // A workaround for missing omit nil functionality.

--- a/openapi/spec_test.go
+++ b/openapi/spec_test.go
@@ -1,9 +1,34 @@
 package openapi
 
 import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
 	"reflect"
 	"testing"
 )
+
+// TestClone tests that the Clone function creates a deep copy of the OpenAPI object.
+func TestClone(t *testing.T) {
+	specData, err := os.ReadFile("../testdata/spec.json")
+	require.NoError(t, err)
+
+	var original OpenAPI
+	err = json.Unmarshal(specData, &original)
+	require.NoError(t, err)
+
+	clone, err := Clone(&original)
+	require.NoError(t, err)
+
+	originalJSON, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	cloneJSON, err := json.Marshal(clone)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(originalJSON), string(cloneJSON))
+}
 
 // TestYAMLMarshalingRefs tests that spec types
 // that contains embedded references  are properly

--- a/testdata/label_spec.json
+++ b/testdata/label_spec.json
@@ -1,0 +1,171 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Test Server",
+        "description": "This is a test server.",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://foo.bar/{basePath}",
+            "description": "Such Server, Very Wow",
+            "variables": {
+                "basePath": {
+                    "enum": [
+                        "v1",
+                        "v2",
+                        "beta"
+                    ],
+                    "default": "v2",
+                    "description": "version of the API"
+                }
+            }
+        }
+    ],
+    "paths": {
+        "/test/{a}/{b}": {
+            "get": {
+                "operationId": "GetTest2",
+                "parameters": [
+                    {
+                        "name": "a",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "b",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    },
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "security": [
+                    {},
+                    {
+                        "oauth2": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/test/{c}": {
+            "post": {
+                "operationId": "PostTest",
+                "parameters": [
+                    {
+                        "name": "c",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PostTestInput"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "FizzCustomTime": {
+                "type": "object",
+                "description": "This is Z",
+                "example": "2022-02-07T18:00:00"
+            },
+            "FizzT": {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "string",
+                        "description": "This is X"
+                    },
+                    "y": {
+                        "type": "integer",
+                        "description": "This is Y",
+                        "format": "int32"
+                    },
+                    "z": {
+                        "$ref": "#/components/schemas/FizzCustomTime"
+                    }
+                }
+            },
+            "PostTestInput": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "description": "A short message"
+                    },
+                    "value": {
+                        "type": "object",
+                        "description": "A nullable value of arbitrary type",
+                        "nullable": true
+                    }
+                }
+            }
+        },
+        "securitySchemes": {
+            "api_key": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "api_key"
+            },
+            "oauth2": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://example.com/api/oauth/dialog",
+                        "scopes": {
+                            "read:pets": "read your pets",
+                            "write:pets": "modify pets in your account"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "security": [
+        {
+            "api_key": []
+        },
+        {
+            "oauth2": [
+                "write:pets",
+                "read:pets"
+            ]
+        }
+    ]
+}

--- a/testdata/label_spec.yaml
+++ b/testdata/label_spec.yaml
@@ -1,0 +1,107 @@
+openapi: 3.0.1
+info:
+  title: Test Server
+  description: This is a test server.
+  version: 1.0.0
+servers:
+  - url: https://foo.bar/{basePath}
+    description: Such Server, Very Wow
+    variables:
+      basePath:
+        enum:
+          - v1
+          - v2
+          - beta
+        default: v2
+        description: version of the API
+paths:
+  /test/{a}/{b}:
+    get:
+      operationId: GetTest2
+      parameters:
+        - name: a
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: b
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: q
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+      security:
+        - {}
+        - oauth2:
+            - write:pets
+            - read:pets
+  /test/{c}:
+    post:
+      operationId: PostTest
+      parameters:
+        - name: c
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PostTestInput'
+      responses:
+        "201":
+          description: Created
+components:
+  schemas:
+    FizzCustomTime:
+      type: object
+      description: This is Z
+      example: 2022-02-07T18:00:00
+    FizzT:
+      type: object
+      properties:
+        x:
+          type: string
+          description: This is X
+        "y":
+          type: integer
+          description: This is Y
+          format: int32
+        z:
+          $ref: '#/components/schemas/FizzCustomTime'
+    PostTestInput:
+      type: object
+      properties:
+        message:
+          type: string
+          description: A short message
+        value:
+          type: object
+          description: A nullable value of arbitrary type
+          nullable: true
+  securitySchemes:
+    api_key:
+      type: apiKey
+      in: header
+      name: api_key
+    oauth2:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://example.com/api/oauth/dialog
+          scopes:
+            read:pets: read your pets
+            write:pets: modify pets in your account
+security:
+  - api_key: []
+  - oauth2:
+      - write:pets
+      - read:pets


### PR DESCRIPTION
Using labels instead of tags as tag is reserved work in openapi spec.

A `IncludeLabels` field is added to the `OpenAPI` struct, with tags `json:"-"` and `yaml:"-"` so it is omitted when generating it.
A `Labels` is added for the `Operation` (which is the endpoint) and a fizz OperationFunc is added to set this. For example:
```
fizz.GET("/test/:a/:b", []OperationOption{
		ID("GetTest2"),
		InputModel(&testInputModel{}),
		Labels([]string{"internal", "not-for-customers"}),
	}, tonic.Handler(func(c *gin.Context) error {
		return nil
	}, 200))
```

When asking for the openapi struct it is deep copied and then modified taking the given options